### PR TITLE
Improve commands: alias, chain, reuse/recall

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,10 @@ Default configuration
     },
     "deepnested-cmd": {
       "command": ["echo deep nested command %args%"]
+    },
+    "host-cmd": {
+      "service": "@host",
+      "command": "docker-compose version"
     }
   }
 }
@@ -77,6 +81,7 @@ Notes:
 - The `"file"` value can be array or string.
 - The `"actions"[\d]."command"` can be either array or string.
 - The command can be reused or recalled by prefixing it with `@` (see sample above).
+- The command that should run in host context will need `"service"` value of `"@host"` (see sample above).
 
 ## Usage
 

--- a/readme.md
+++ b/readme.md
@@ -21,10 +21,11 @@ Optionally install it locally, to pin down versions if required.
 
 
 ## Configuration
- 
+
 Configuration of DOPR can be done either via `package.json` under the `dopr` key or with a provided file defaulting to `docker-project.json`.
 
-Default configuration
+Sample configuration (based on [default configuration](./src/defaulConfig.json)):
+
 ```json
 {
   "file": ["./docker/docker-compose.yml"],
@@ -48,14 +49,14 @@ Default configuration
       "exec": false
     },
     "bash": "%action% %args%",
-    "composer": "composer %action% %args%",
+    "composer": "%action% %args%",
     "node": {
-      "command": "node %action% %args%",
+      "command": "%action% %args%",
       "user": "node"
     },
-    "npm": "npm %action% %args%",
-    "git": "git %action% %args%",
-    "yarn": "yarn %action% %args%",
+    "npm": "%action% %args%",
+    "git": "%action% %args%",
+    "yarn": "%action% %args%",
     "multiple-cmd": {
       "command": ["echo multiple command as array", "@nested-cmd arg1 arg2"]
     },

--- a/readme.md
+++ b/readme.md
@@ -48,14 +48,14 @@ Default configuration
       "exec": false
     },
     "bash": "%action% %args%",
-    "composer": "%action% %args%",
+    "composer": "composer %action% %args%",
     "node": {
-      "command": "%action% %args%",
+      "command": "node %action% %args%",
       "user": "node"
     },
-    "npm": "%action% %args%",
-    "git": "%action% %args%",
-    "yarn": "%action% %args%",
+    "npm": "npm %action% %args%",
+    "git": "git %action% %args%",
+    "yarn": "yarn %action% %args%",
     "multiple-cmd": {
       "command": ["echo multiple command as array", "@nested-cmd arg1 arg2"]
     },

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Install it globally for quick access
 
 Optionally install it locally, to pin down versions if required.
 
-    $ npm i --save @crazyfactory/docker-project-cli 
+    $ npm i --save @crazyfactory/docker-project-cli
 
 
 ## Configuration
@@ -55,7 +55,16 @@ Default configuration
     },
     "npm": "%action% %args%",
     "git": "%action% %args%",
-    "yarn": "%action% %args%"
+    "yarn": "%action% %args%",
+    "multiple-cmd": {
+      "command": ["echo multiple command as array", "@nested-cmd arg1 arg2"]
+    },
+    "nested-cmd": {
+      "command": ["echo nested command %args%", "@deepnested-cmd --opt1 val1 --opt2 val2"]
+    },
+    "deepnested-cmd": {
+      "command": ["echo deep nested command %args%"]
+    }
   }
 }
 ```
@@ -66,6 +75,8 @@ Notes:
 - The `node` will be launched with the user `node` by default.
 - This will use a different config if NODE_ENV is set to *production* or if dopr is with `--env production`.
 - The `"file"` value can be array or string.
+- The `"actions"[\d]."command"` can be either array or string.
+- The command can be reused or recalled by prefixing it with `@` (see sample above).
 
 ## Usage
 
@@ -76,8 +87,8 @@ To start you project in deamon mode run
 
     $ dopr up -d
 
-You can similarly use `down` and `stop`, just like you would with `docker-compose` directly. 
- 
+You can similarly use `down` and `stop`, just like you would with `docker-compose` directly.
+
 ### custom commands
 
 You can add simple custom commands, but we add some by default. They are passed through to the service specified in your dopr configuration.
@@ -86,7 +97,7 @@ For instance to open a bash session just run
 
     $ dopr bash
 
-You can similarly access `node`, `npm`, `git` and `composer` like so 
+You can similarly access `node`, `npm`, `git` and `composer` like so
 
     $ dopr npm run my-script
 

--- a/readme.md
+++ b/readme.md
@@ -24,8 +24,7 @@ Optionally install it locally, to pin down versions if required.
 
 Configuration of DOPR can be done either via `package.json` under the `dopr` key or with a provided file defaulting to `docker-project.json`.
 
-Sample configuration (based on [default configuration](./src/defaulConfig.json)):
-
+**Default configuration:**
 ```json
 {
   "file": ["./docker/docker-compose.yml"],
@@ -37,6 +36,10 @@ Sample configuration (based on [default configuration](./src/defaulConfig.json))
       "exec": false
     },
     "up": {
+      "command": "%action% %args%",
+      "exec": false
+    },
+    "pull": {
       "command": "%action% %args%",
       "exec": false
     },
@@ -54,9 +57,28 @@ Sample configuration (based on [default configuration](./src/defaulConfig.json))
       "command": "%action% %args%",
       "user": "node"
     },
-    "npm": "%action% %args%",
+    "npm": {
+      "command": "%action% %args%",
+      "user": "node"
+    },
     "git": "%action% %args%",
-    "yarn": "%action% %args%",
+    "yarn": "%action% %args%"
+  }
+}
+```
+
+*Notes:*
+- This will relay `up`, `down`, `start` and `stop` to `docker-compose -f <file> $params$`
+- This will add custom commands like `dopr bash ...`, `dopr composer ...` and `dopr optimize`
+- The `node` will be launched with the user `node` by default.
+- This will use a different config if NODE_ENV is set to *production* or if dopr is with `--env production`.
+- The `"file"` value can be array or string.
+
+**Sample configuration with all usecases:**
+
+```json
+{
+  "actions": {
     "multiple-cmd": {
       "command": ["echo multiple command as array", "@nested-cmd arg1 arg2"]
     },
@@ -74,13 +96,8 @@ Sample configuration (based on [default configuration](./src/defaulConfig.json))
 }
 ```
 
-Notes:
-- This will relay `up`, `down`, `start` and `stop` to `docker-compose -f <file> $params$`
-- This will add custom commands like `dopr bash ...`, `dopr composer ...` and `dopr optimize`
-- The `node` will be launched with the user `node` by default.
-- This will use a different config if NODE_ENV is set to *production* or if dopr is with `--env production`.
-- The `"file"` value can be array or string.
-- The `"actions"[\d]."command"` can be either array or string.
+*Notes:*
+- The `"actions".[$key]."command"` can be either array or string.
 - The command can be reused or recalled by prefixing it with `@` (see sample above).
 - The command that should run in host context will need `"service"` value of `"@host"` (see sample above).
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -114,7 +114,7 @@ if (cliAction.exec && !cliAction.service) {
 
 const dockerComposeFiles = [];
 
-// Run commands synchronously one after another!
+// Validate/sanitize all docker-compose files!
 cliAction.file.forEach((file, pos) => {
     file = path.resolve(file);
 
@@ -153,6 +153,7 @@ const exitHandler = code => {
     }
 };
 
+// Run commands synchronously one after another!
 cliAction.command.forEach(command => {
     if (program.verbose) {
         console.log(chalk.gray('ENV: ' + env));

--- a/src/cli.js
+++ b/src/cli.js
@@ -114,6 +114,7 @@ if (cliAction.exec && !cliAction.service) {
 
 const dockerComposeFiles = [];
 
+// Run commands synchronously one after another!
 cliAction.file.forEach((file, pos) => {
     file = path.resolve(file);
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const path = require('path');
-const {spawnSync} = require('child_process');
+const {execSync, spawnSync} = require('child_process');
 const program = require('commander');
 const chalk = require('chalk');
 const deepAssign = require('deep-assign');
@@ -169,6 +169,11 @@ cliAction.command.forEach(command => {
 
         // Fire!
         return exitHandler(spawnSync('dopr ', refArgs, cliOptions).status);
+    }
+
+    // Command is expected to run in host context!
+    if (cliAction.service === '@host') {
+        return execSync(command, cliOptions);
     }
 
     // Parse command

--- a/src/internals.spec.js
+++ b/src/internals.spec.js
@@ -1,6 +1,6 @@
 import test from 'ava';
 
-import {preprocessArgs, parseConfigActions, parseConfig} from './internals';
+import {preprocessArgs, parseConfigActions, parseConfig, collect} from './internals';
 
 test('preprocessArgs() with empty array', t => {
     t.deepEqual(preprocessArgs(['node.exe', 'cli.js']), {
@@ -144,4 +144,11 @@ test('parseConfig()', t => {
     };
 
     t.deepEqual(parseConfig(config), expected);
+});
+
+test('collect()', t => {
+    const memo = [];
+
+    t.deepEqual(collect(1, memo), [1]);
+    t.deepEqual(collect('a', memo), [1, 'a']);
 });


### PR DESCRIPTION
Closes #21 
Closes #24 
Closes #25 

Given below configuration:
```json
{
  "actions": {
    "multiple-cmd": {
      "command": ["echo multiple command as array", "@nested-cmd arg1 arg2"]
    },
    "nested-cmd": {
      "command": ["echo nested command %args%", "@deepnested-cmd --opt1 val1 --opt2 val2"]
    },
    "deepnested-cmd": {
      "command": ["echo deep nested command %args%"]
    },
    "host-cmd": {
      "service": "@host",
      "command": "docker-compose version"
    }
  }
}
```
when `dopr multiple-cmd` is run, it yields:
```
multiple command as array
nested command arg1 arg2
deep nested command --opt1 val1 --opt2 val2
docker-compose version 1.10.0, build 4bd6f1a
docker-py version: 2.0.1
CPython version: 2.7.9
OpenSSL version: OpenSSL 1.0.1t  3 May 2016
```