### PR TITLE
Support `--list` or `-l` to list registered actions (including default)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,37 +32,63 @@ Configuration of DOPR can be done either via `package.json` under the `dopr` key
   "exec": true,
   "actions": {
     "down": {
+      "comment": "Stop and destroy the docker containers",
       "command": "%action% %args%",
       "exec": false
     },
     "up": {
+      "comment": "Bring the docker containers up and live",
       "command": "%action% %args%",
       "exec": false
     },
     "pull": {
+      "comment": "Pull the latest versions of docker containers",
       "command": "%action% %args%",
       "exec": false
     },
     "start": {
+      "comment": "Start the docker containers",
       "command": "%action% %args%",
       "exec": false
     },
     "stop": {
+      "comment": "Stop the docker containers",
       "command": "%action% %args%",
       "exec": false
     },
-    "bash": "%action% %args%",
-    "composer": "%action% %args%",
+    "ip": {
+      "comment": "Print IP address of given container",
+      "service": "@host",
+      "command": "docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' %args%"
+    },
+    "bash": {
+      "comment": "Open the interactive terminal from default service container",
+      "command": "%action% %args%"
+    },
+    "composer": {
+      "comment": "Run the composer command in default service container",
+      "command": "%action% %args%"
+    },
     "node": {
+      "comment": "Run the node command in default service container",
       "command": "%action% %args%",
       "user": "node"
     },
     "npm": {
+      "comment": "Run the npm command in default service container",
       "command": "%action% %args%",
       "user": "node"
     },
-    "git": "%action% %args%",
-    "yarn": "%action% %args%"
+    "git": {
+      "comment": "Run the git command in default service container",
+      "command": "%action% %args%",
+      "user": "node"
+    },
+    "yarn": {
+      "comment": "Run the yarn command in default service container",
+      "command": "%action% %args%",
+      "user": "node"
+    }
   }
 }
 ```
@@ -73,6 +99,8 @@ Configuration of DOPR can be done either via `package.json` under the `dopr` key
 - The `node` will be launched with the user `node` by default.
 - This will use a different config if NODE_ENV is set to *production* or if dopr is with `--env production`.
 - The `"file"` value can be array or string.
+- Use `dopr ip <container-name>` to print the IP address of container.
+- To change service container for above default actions simply extend the node with override `"service"` only.
 
 **Sample configuration with all usecases:**
 

--- a/readme.md
+++ b/readme.md
@@ -81,13 +81,11 @@ Configuration of DOPR can be done either via `package.json` under the `dopr` key
     },
     "git": {
       "comment": "Run the git command in default service container",
-      "command": "%action% %args%",
-      "user": "node"
+      "command": "%action% %args%"
     },
     "yarn": {
       "comment": "Run the yarn command in default service container",
-      "command": "%action% %args%",
-      "user": "node"
+      "command": "%action% %args%"
     }
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -82,9 +82,9 @@ if (program.list) {
     console.log('Available actions:\n');
 
     Object.keys(config.actions).forEach(action => {
-        action = action.padEnd(16, ' ');
+        const comment = config.actions[action].comment || '';
 
-        console.log('  ' + action + ' ' + chalk.gray(config.actions[action].comment || ''));
+        console.log('  ' + action.padEnd(16, ' ') + chalk.gray(comment));
     });
 
     process.exit(0);

--- a/src/cli.js
+++ b/src/cli.js
@@ -32,6 +32,7 @@ program
     .option('-p, --privileged', 'Give extended privileges to the executed command process')
     .option('-v, --verbose', 'Adds additional logging')
     .option('-d, --detached', 'Detached mode: Run command in the background.')
+    .option('-l, --list', 'List the available actions that can be run as ' + chalk.gray('dopr <action>'))
     .parse(dockerProjectArgs);
 
 // Set defaults
@@ -76,6 +77,18 @@ if (doprConfig && typeof doprConfig.file === 'string') {
 const mergedConfig = deepAssign({}, defaultConfig, packageConfig, doprConfig);
 const environmentConfig = (mergedConfig.environments && mergedConfig.environments[env]) || {};
 const config = deepAssign({}, mergedConfig, environmentConfig);
+
+if (program.list) {
+    console.log('Available actions:\n');
+
+    Object.keys(config.actions).forEach(action => {
+        action = action.padEnd(16, ' ');
+
+        console.log('  ' + action + ' ' + chalk.gray(config.actions[action].comment || ''));
+    });
+
+    process.exit(0);
+}
 
 // Default action
 const defaultAction = {

--- a/src/defaultConfig.json
+++ b/src/defaultConfig.json
@@ -4,36 +4,57 @@
   "exec": true,
   "actions": {
     "down": {
+      "comment": "Stop and destroy the docker containers",
       "command": "%action% %args%",
       "exec": false
     },
     "up": {
+      "comment": "Bring the docker containers up and live",
       "command": "%action% %args%",
       "exec": false
     },
     "pull": {
+      "comment": "Pull the latest versions of docker containers",
       "command": "%action% %args%",
       "exec": false
     },
     "start": {
+      "comment": "Start the docker containers",
       "command": "%action% %args%",
       "exec": false
     },
     "stop": {
+      "comment": "Stop the docker containers",
       "command": "%action% %args%",
       "exec": false
     },
-    "bash": "%action% %args%",
-    "composer": "%action% %args%",
+    "bash": {
+      "comment": "Open the interactive terminal from default service container",
+      "command": "%action% %args%"
+    },
+    "composer": {
+      "comment": "Run the composer command in default service container",
+      "command": "%action% %args%"
+    },
     "node": {
+      "comment": "Run the node command in default service container",
       "command": "%action% %args%",
       "user": "node"
     },
     "npm": {
+      "comment": "Run the npm command in default service container",
       "command": "%action% %args%",
       "user": "node"
     },
-    "git": "%action% %args%",
-    "yarn": "%action% %args%"
+    "git": {
+      "comment": "Run the git command in default service container",
+      "command": "%action% %args%",
+      "user": "node"
+    },
+    "yarn": {
+      "comment": "Run the yarn command in default service container",
+      "command": "%action% %args%",
+      "user": "node"
+    }
   }
 }

--- a/src/defaultConfig.json
+++ b/src/defaultConfig.json
@@ -53,13 +53,11 @@
     },
     "git": {
       "comment": "Run the git command in default service container",
-      "command": "%action% %args%",
-      "user": "node"
+      "command": "%action% %args%"
     },
     "yarn": {
       "comment": "Run the yarn command in default service container",
-      "command": "%action% %args%",
-      "user": "node"
+      "command": "%action% %args%"
     }
   }
 }

--- a/src/defaultConfig.json
+++ b/src/defaultConfig.json
@@ -28,6 +28,11 @@
       "command": "%action% %args%",
       "exec": false
     },
+    "ip": {
+      "comment": "Print container IP address",
+      "service": "@host",
+      "command": "docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' %args%"
+    },
     "bash": {
       "comment": "Open the interactive terminal from default service container",
       "command": "%action% %args%"


### PR DESCRIPTION
closes #31 

Also added, `dopr ip <container_name>` a handy alias to know the container IP addr, as i find myself doing it manually with 
`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' container-name`
many times and that's so inconvenient.

**Sample `dopr --list` output**

```
Available actions:

  down            Stop and destroy the docker containers
  up              Bring the docker containers up and live
  pull            Pull the latest versions of docker containers
  start           Start the docker containers
  stop            Stop the docker containers
  ip              Print container IP address
  bash            Open the interactive terminal from default service container
  composer        Run the composer command in default service container
  node            Run the node command in default service container
  npm             Run the npm command in default service container
  git             Run the git command in default service container
  yarn            Run the yarn command in default service container
  pre-test        
  lint            
  lint:fix        
  test            
  codecept        
  dump-db    
```
